### PR TITLE
Match materiel and personnel by itemType for translation support

### DIFF
--- a/module/bob-role-sheet.js
+++ b/module/bob-role-sheet.js
@@ -202,14 +202,14 @@ export class BoBRoleSheet extends BoBSheet {
     html.find('.materiel-add').click( async (ev) => {
       const itemType = $(ev.currentTarget).data("mtype");
       let mItems = await BoBHelpers.getAllItemsByType( "materiel", game );
-      let item = mItems.find( i => i.name === itemType );
+      let item = mItems.find( i => i.system.itemType === itemType );
       await this.actor.createEmbeddedDocuments( "Item", [ item ] );
     });
 
     html.find('.personnel-add').click( async (ev) => {
       const itemType = $(ev.currentTarget).data("mtype");
       let mItems = await BoBHelpers.getAllItemsByType( "personnel", game );
-      let item = mItems.find( i => i.name === itemType );
+      let item = mItems.find( i => i.system.itemType === itemType );
       await this.actor.createEmbeddedDocuments( "Item", [ item ] );
     });
 


### PR DESCRIPTION
Hi friend.

We are working on a translation module to spanish with Babele. That kind of matches (by name) breaks our translation. 

With this change your system still working fine (in fact in the template you match by itemType por that items) and our translation doesn't explodes XD

Thank you.